### PR TITLE
Tweak ufw tasks

### DIFF
--- a/Ansible/roles/common/tasks/main.yml
+++ b/Ansible/roles/common/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
-- name: Enable UFW
-  ufw:
-    state: enabled
-
-- name: Enable UFW logging
-  ufw:
-    logging: 'True'
+- name: Ensure UFW is installed
+  package:
+    name: ufw
+    state: present
 
 - name: Allow SSH access from internal networks
   ufw:
@@ -16,3 +13,11 @@
   with_items:
     - <REDACTED>/24
     - <REDACTED>/24
+
+- name: Enable UFW logging
+  ufw:
+    logging: 'True'
+
+- name: Enable UFW
+  ufw:
+    state: enabled


### PR DESCRIPTION
Logically you would want to add your allow rules before enabling UFW to prevent locking yourself out.

Also added a task to install UFW if required, otherwise if it's missing the playbook would fail.